### PR TITLE
Debouncing resize text function and keeping it DRY

### DIFF
--- a/notie.js
+++ b/notie.js
@@ -100,16 +100,36 @@ var notie = function(){
     alert_inner.style.verticalAlign = 'middle';
     alert_outer.appendChild(alert_inner);
 
+    // DEBOUCNE FOR RESIZE LISTENER
+    // *********************************************
+    var resizeListener = function resizeListener(ele) {
+        if (window.innerWidth <= font_change_screen_width) { ele.style.fontSize = font_size_small; }
+        else { ele.style.fontSize = font_size_big; }
+    };
+    
+    // Borrowed from Underscore.js
+    var _debounce = function _debounce(func, wait, immediate) {
+        var timeout;
+        return function() {
+            var context = this, args = arguments;
+            var later = function() {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    }
+    
     // Initialize notie text
     var alert_text = document.createElement('span');
     alert_text.id = alert_text_id;
     alert_text.style.color = alert_color_text;
     if (window.innerWidth <= font_change_screen_width) { alert_text.style.fontSize = font_size_small; }
     else { alert_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { alert_text.style.fontSize = font_size_small; }
-        else { alert_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, alert_text), 500), true);
     alert_inner.appendChild(alert_text);
 
     // Attach notie to the body element
@@ -304,10 +324,7 @@ var notie = function(){
     confirm_text.style.color = confirm_and_input_color_text;
     if (window.innerWidth <= font_change_screen_width) { confirm_text.style.fontSize = font_size_small; }
     else { confirm_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { confirm_text.style.fontSize = font_size_small; }
-        else { confirm_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, confirm_text), 500), true);
     confirm_inner.appendChild(confirm_text);
 
     var confirm_yes_text = document.createElement('span');
@@ -315,10 +332,7 @@ var notie = function(){
     confirm_yes_text.style.color = confirm_and_input_color_yes_text;
     if (window.innerWidth <= font_change_screen_width) { confirm_yes_text.style.fontSize = font_size_small; }
     else { confirm_yes_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { confirm_yes_text.style.fontSize = font_size_small; }
-        else { confirm_yes_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, confirm_yes_text), 500), true);
     confirm_yes.appendChild(confirm_yes_text);
 
     var confirm_no_text = document.createElement('span');
@@ -326,10 +340,7 @@ var notie = function(){
     confirm_no_text.style.color = confirm_and_input_color_no_text;
     if (window.innerWidth <= font_change_screen_width) { confirm_no_text.style.fontSize = font_size_small; }
     else { confirm_no_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { confirm_no_text.style.fontSize = font_size_small; }
-        else { confirm_no_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, confirm_no_text), 500), true);
     confirm_no.appendChild(confirm_no_text);
 
     // Attach confirm elements to the body element
@@ -509,10 +520,7 @@ var notie = function(){
     input_field.style.fontSize = font_size_big;
     if (window.innerWidth <= font_change_screen_width) { input_field.style.fontSize = font_size_small; }
     else { input_field.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { input_field.style.fontSize = font_size_small; }
-        else { input_field.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, input_field), 500), true);
     input_div.appendChild(input_field);
 
     var input_yes = document.createElement('div');
@@ -542,10 +550,7 @@ var notie = function(){
     input_text.style.color = confirm_and_input_color_text;
     if (window.innerWidth <= font_change_screen_width) { input_text.style.fontSize = font_size_small; }
     else { input_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { input_text.style.fontSize = font_size_small; }
-        else { input_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, input_text), 500), true);
     input_inner.appendChild(input_text);
 
     var input_yes_text = document.createElement('span');
@@ -553,10 +558,7 @@ var notie = function(){
     input_yes_text.style.color = confirm_and_input_color_yes_text;
     if (window.innerWidth <= font_change_screen_width) { input_yes_text.style.fontSize = font_size_small; }
     else { input_yes_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { input_yes_text.style.fontSize = font_size_small; }
-        else { input_yes_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, input_yes_text), 500), true);
     input_yes.appendChild(input_yes_text);
 
     var input_no_text = document.createElement('span');
@@ -564,10 +566,7 @@ var notie = function(){
     input_no_text.style.color = confirm_and_input_color_no_text;
     if (window.innerWidth <= font_change_screen_width) { input_no_text.style.fontSize = font_size_small; }
     else { input_no_text.style.fontSize = font_size_big; }
-    window.addEventListener('resize', function(){
-        if (window.innerWidth <= font_change_screen_width) { input_no_text.style.fontSize = font_size_small; }
-        else { input_no_text.style.fontSize = font_size_big; }
-    }, true);
+    window.addEventListener('resize', _debounce(resizeListener.bind(null, input_no_text), 500), true);
     input_no.appendChild(input_no_text);
 
     // Attach input elements to the body element
@@ -688,14 +687,12 @@ var notie = function(){
         document.body.style.height = '100%;';
         document.body.style.overflow = 'hidden';
     }
+
     function scroll_enable() {
         document.body.style.height = original_body_height;
         document.body.style.overflow = original_body_overflow;
     }
-    
-    
-    
-    
+
     return {
         alert: alert,
         confirm: confirm,


### PR DESCRIPTION
I noticed whilst taking a look through the code that the resize listener was pretty much identical throughout the package, which was around 5 times.

I also noticed there was no de-bounce or throttling, which means it was requesting window.innerWidth constantly whilst resizing, I believe this causes a re-flow but can't find any concrete information online. Either way it's always good to debounce any non-essential functions.