### PR TITLE
Add a trailing slash at the end of the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/jaredreich/notie.js](https://badges.gitter.im/jaredreich/notie.js.svg)](https://gitter.im/jaredreich/notie.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 notie.js is a clean and simple notification plugin (alert/growl style) for javascript, with no dependencies.
-Demo: https://jaredreich.com/projects/notie.js
+Demo: https://jaredreich.com/projects/notie.js/
 
 #### With notie.js you can:
 * Alert users


### PR DESCRIPTION
I was not eager to click the link because I thought it was going to download a .js file to my machine. The trailing slash makes it clear that it's only the name of the route